### PR TITLE
Fix Decimal parameterValue and Parameter Typo

### DIFF
--- a/src/EPR.Calculator.API/Controllers/DefaultParameterSettingController.cs
+++ b/src/EPR.Calculator.API/Controllers/DefaultParameterSettingController.cs
@@ -53,7 +53,7 @@ namespace EPR.Calculator.API.Controllers
                     {
                         this._context.DefaultParameterSettingDetail.Add(new DefaultParameterSettingDetail
                         {
-                            ParameterValue = templateValue.ParameterValue,
+                            ParameterValue = templateValue.ParameterValue.Value,
                             ParameterUniqueReferenceId = templateValue.ParameterUniqueReferenceId,
                             DefaultParameterSettingMaster = defaultParamSettingMaster
                         });

--- a/src/EPR.Calculator.API/Dtos/SchemeParameterTemplateValueDto.cs
+++ b/src/EPR.Calculator.API/Dtos/SchemeParameterTemplateValueDto.cs
@@ -6,6 +6,6 @@ namespace EPR.Calculator.API.Dtos
     public class SchemeParameterTemplateValueDto
     {
         public string ParameterUniqueReferenceId { get; set; }
-        public decimal ParameterValue { get; set; }
+        public decimal? ParameterValue { get; set; }
     }
 }

--- a/src/EPR.Calculator.API/Validators/CreateDefaultParameterDataValidator.cs
+++ b/src/EPR.Calculator.API/Validators/CreateDefaultParameterDataValidator.cs
@@ -52,7 +52,7 @@ namespace api.Validators
                         ParameterUniqueRef = defaultParameterTemplateMaster.ParameterUniqueReferenceId,
                         ParameterType = defaultParameterTemplateMaster.ParameterType,
                         ParameterCategory = defaultParameterTemplateMaster.ParameterCategory,
-                        Message = $"Expecting at least One with Parameter Type {this.FormattedErrorString(defaultParameterTemplateMaster)}",
+                        Message = $"Expecting at least One with {this.FormattedErrorString(defaultParameterTemplateMaster)}",
                         Description = ""
                     };
                     errors.Add(error);
@@ -68,7 +68,7 @@ namespace api.Validators
                             ParameterUniqueRef = defaultParameterTemplateMaster.ParameterUniqueReferenceId,
                             ParameterType = defaultParameterTemplateMaster.ParameterType,
                             ParameterCategory = defaultParameterTemplateMaster.ParameterCategory,
-                            Message = $"{this.FormattedErrorStringForValues(defaultParameterTemplateMaster, matchingTemplate.ParameterValue)}",
+                            Message = $"{this.FormattedErrorStringForValues(defaultParameterTemplateMaster, matchingTemplate.ParameterValue.Value)}",
                             Description = ""
                         };
                         errors.Add(error);

--- a/src/EPR.Calculator.API/Validators/SchemeParameterTemplateValueValidator.cs
+++ b/src/EPR.Calculator.API/Validators/SchemeParameterTemplateValueValidator.cs
@@ -9,7 +9,7 @@ namespace EPR.Calculator.API.Validators
         {
             public SchemeParameterTemplateValueValidator()
             {
-                RuleFor(x => x.ParameterValue).NotEmpty().WithMessage("ParameterValue is missing");
+                RuleFor(x => x.ParameterValue).NotNull().WithMessage("ParameterValue is missing");
                 RuleFor(x => x.ParameterUniqueReferenceId).NotEmpty().WithMessage("ParameterUniqueReferenceId is missing");
             }
         }


### PR DESCRIPTION
Bug Fix for the 2 issues raised

Issue 1: When Parameter Value is 0. The Fluent validator does not work.
Issue 2: Typo in the Parameter Type

Resolution - Issue 1 - Make the Parameter Value nullable