### PR TITLE
Add API endpoint: GET API - /v1/classificationByFinancialYear

### DIFF
--- a/src/EPR.Calculator.API/Controllers/CalculatorController.cs
+++ b/src/EPR.Calculator.API/Controllers/CalculatorController.cs
@@ -358,6 +358,29 @@ namespace EPR.Calculator.API.Controllers
             }
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("ClassificationByFinancialYear")]
+        public async Task<IActionResult> ClassificationByFinancialYear([FromQuery, Required] string financialYear)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(financialYear) || !this.IsValidFinancialYear(financialYear))
+                {
+                    return this.BadRequest("Invalid financial year format. Expected format: YYYY-YY (e.g., 2024-25).");
+                }
+
+                // mocked options
+                var options = new[] { "Initial run", "Test run" };
+
+                return this.Ok(options);
+            }
+            catch (Exception exception)
+            {
+                return this.StatusCode(StatusCodes.Status500InternalServerError, exception);
+            }
+        }
+
         private string DataPreChecksBeforeInitialisingCalculatorRun(CalculatorRunFinancialYear financialYear)
         {
             // Get active default parameter settings for the given financial year
@@ -402,6 +425,11 @@ namespace EPR.Calculator.API.Controllers
 
             // All good, return empty string
             return string.Empty;
+        }
+
+        private bool IsValidFinancialYear(string financialYear)
+        {
+            return Regex.IsMatch(financialYear, @"^\d{4}-\d{2}$");
         }
     }
 }


### PR DESCRIPTION
This adds an endpoint GET API - /v1/classificationByFinancialYear

It expects a required parameter financialYear validated to the format '2024-25' 

Returning just two values currently as implementation to retrieve from the database isn't to be done yet as per refinement call.

"Initial run", "Test run"