### PR TITLE
Correction to Migration SQL - use EXEC(@Sql) instead of Alter Procedure directly

### DIFF
--- a/src/EPR.Calculator.API.Data/Migrations/20250516101138_AddTradingNameToProducerDetail.Designer.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20250516101138_AddTradingNameToProducerDetail.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.Calculator.API.Data.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    [Migration("20250513190717_AddTradingNameToProducerDetail")]
+    [Migration("20250516101138_AddTradingNameToProducerDetail")]
     partial class AddTradingNameToProducerDetail
     {
         /// <inheritdoc />
@@ -1495,7 +1495,9 @@ namespace EPR.Calculator.API.Data.Migrations
                         .HasColumnName("subsidiary_id");
 
                     b.Property<string>("TradingName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(4000)
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("trading_name");
 
                     b.HasKey("Id");
 

--- a/src/EPR.Calculator.API.Data/Migrations/20250516101138_AddTradingNameToProducerDetail.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20250516101138_AddTradingNameToProducerDetail.cs
@@ -14,6 +14,7 @@ namespace EPR.Calculator.API.Data.Migrations
                 name: "trading_name",
                 table: "producer_detail",
                 type: "nvarchar(4000)",
+                maxLength: 4000,
                 nullable: true);
         }
 

--- a/src/EPR.Calculator.API.Data/Migrations/20250516101257_UpdateOrganisationSproc.Designer.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20250516101257_UpdateOrganisationSproc.Designer.cs
@@ -12,8 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.Calculator.API.Data.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    [Migration("20250513130643_AlterCreateRunOrganisationSproc")]
-    partial class AlterCreateRunOrganisationSproc
+    [Migration("20250516101257_UpdateOrganisationSproc")]
+    partial class UpdateOrganisationSproc
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -1493,6 +1493,11 @@ namespace EPR.Calculator.API.Data.Migrations
                         .HasMaxLength(400)
                         .HasColumnType("nvarchar(400)")
                         .HasColumnName("subsidiary_id");
+
+                    b.Property<string>("TradingName")
+                        .HasMaxLength(4000)
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("trading_name");
 
                     b.HasKey("Id");
 

--- a/src/EPR.Calculator.API.Data/Migrations/20250516101257_UpdateOrganisationSproc.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20250516101257_UpdateOrganisationSproc.cs
@@ -5,13 +5,22 @@
 namespace EPR.Calculator.API.Data.Migrations
 {
     /// <inheritdoc />
-    public partial class AlterCreateRunOrganisationSproc : Migration
+    public partial class UpdateOrganisationSproc : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            var alterOrgSql = @"
-                ALTER PROCEDURE [dbo].[CreateRunOrganization]
+            // Drop the existing procedure if it exists
+            var dropOrgProcSql = @"
+                IF OBJECT_ID(N'[dbo].[CreateRunOrganization]', N'P') IS NOT NULL
+                    DROP PROCEDURE [dbo].[CreateRunOrganization]";
+            migrationBuilder.Sql(dropOrgProcSql);
+
+            // Recreate the procedure using EXEC(@Sql) pattern
+            var createOrgProcSql = @"
+                DECLARE @Sql NVARCHAR(MAX)
+                SET @Sql = N'
+                CREATE PROCEDURE [dbo].[CreateRunOrganization]
                 (
                     @RunId int,
                     @calendarYear varchar(400),
@@ -58,15 +67,26 @@ namespace EPR.Calculator.API.Data.Migrations
 
                     Update dbo.calculator_run Set calculator_run_organization_data_master_id = @orgDataMasterid where id = @RunId
 
-                END";
-            migrationBuilder.Sql(alterOrgSql);
+                END'
+                EXEC(@Sql)";
+            migrationBuilder.Sql(createOrgProcSql);
         }
+
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            var revertOrgSql = @"
-                ALTER PROCEDURE [dbo].[CreateRunOrganization]
+            // Drop the existing procedure if it exists
+            var dropOrgProcSql = @"
+                IF OBJECT_ID(N'[dbo].[CreateRunOrganization]', N'P') IS NOT NULL
+                    DROP PROCEDURE [dbo].[CreateRunOrganization]";
+            migrationBuilder.Sql(dropOrgProcSql);
+
+            // Recreate the original procedure using EXEC(@Sql)
+            var revertOrgProcSql = @"
+                DECLARE @Sql NVARCHAR(MAX)
+                SET @Sql = N'
+                CREATE PROCEDURE [dbo].[CreateRunOrganization]
                 (
                     @RunId int,
                     @calendarYear varchar(400),
@@ -111,8 +131,10 @@ namespace EPR.Calculator.API.Data.Migrations
 
                     Update dbo.calculator_run Set calculator_run_organization_data_master_id = @orgDataMasterid where id = @RunId
 
-                END";
-            migrationBuilder.Sql(revertOrgSql);
+                END'
+                EXEC(@Sql)";
+            migrationBuilder.Sql(revertOrgProcSql);
         }
+
     }
 }

--- a/src/EPR.Calculator.API.Data/Scripts/migrations.sql
+++ b/src/EPR.Calculator.API.Data/Scripts/migrations.sql
@@ -3821,11 +3821,49 @@ GO
 
 IF NOT EXISTS (
     SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'20250513130643_AlterCreateRunOrganisationSproc'
+    WHERE [MigrationId] = N'20250516101138_AddTradingNameToProducerDetail'
+)
+BEGIN
+    ALTER TABLE [producer_detail] ADD [trading_name] nvarchar(4000) NULL;
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250516101138_AddTradingNameToProducerDetail'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20250516101138_AddTradingNameToProducerDetail', N'8.0.7');
+END;
+GO
+
+COMMIT;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250516101257_UpdateOrganisationSproc'
 )
 BEGIN
 
-                    ALTER PROCEDURE [dbo].[CreateRunOrganization]
+                    IF OBJECT_ID(N'[dbo].[CreateRunOrganization]', N'P') IS NOT NULL
+                        DROP PROCEDURE [dbo].[CreateRunOrganization]
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250516101257_UpdateOrganisationSproc'
+)
+BEGIN
+
+                    DECLARE @Sql NVARCHAR(MAX)
+                    SET @Sql = N'
+                    CREATE PROCEDURE [dbo].[CreateRunOrganization]
                     (
                         @RunId int,
                         @calendarYear varchar(400),
@@ -3872,42 +3910,18 @@ BEGIN
 
                         Update dbo.calculator_run Set calculator_run_organization_data_master_id = @orgDataMasterid where id = @RunId
 
-                    END
+                    END'
+                    EXEC(@Sql)
 END;
 GO
 
 IF NOT EXISTS (
     SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'20250513130643_AlterCreateRunOrganisationSproc'
+    WHERE [MigrationId] = N'20250516101257_UpdateOrganisationSproc'
 )
 BEGIN
     INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'20250513130643_AlterCreateRunOrganisationSproc', N'8.0.7');
-END;
-GO
-
-COMMIT;
-GO
-
-BEGIN TRANSACTION;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'20250513190717_AddTradingNameToProducerDetail'
-)
-BEGIN
-    ALTER TABLE [producer_detail] ADD [trading_name] nvarchar(4000) NULL;
-END;
-GO
-
-IF NOT EXISTS (
-    SELECT * FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'20250513190717_AddTradingNameToProducerDetail'
-)
-BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'20250513190717_AddTradingNameToProducerDetail', N'8.0.7');
+    VALUES (N'20250516101257_UpdateOrganisationSproc', N'8.0.7');
 END;
 GO
 


### PR DESCRIPTION
This PR is to address a previous incorrect way of updating the CreateOrganisation SPROC.

This uses EXEC(@Sql) by passing in a constructed SQL string.