### PR TITLE
586548 - Nullify reason on previously rejected instruction when accepting

### DIFF
--- a/src/EPR.Calculator.API.UnitTests/Services/BillingFileServiceTests.cs
+++ b/src/EPR.Calculator.API.UnitTests/Services/BillingFileServiceTests.cs
@@ -474,6 +474,7 @@ namespace EPR.Calculator.API.UnitTests.Services
             {
                 Status = BillingStatus.Accepted.ToString(),
                 OrganisationIds = new List<int> { producerId },
+
                 // ReasonForRejection intentionally omitted
             };
 

--- a/src/EPR.Calculator.API/Services/BillingFileService.cs
+++ b/src/EPR.Calculator.API/Services/BillingFileService.cs
@@ -476,6 +476,10 @@ namespace EPR.Calculator.API.Services
             {
                 row.ReasonForRejection = produceBillingInstuctionRequestDto.ReasonForRejection;
             }
+            else
+            {
+                row.ReasonForRejection = null;
+            }
 
             row.LastModifiedAcceptReject = DateTime.UtcNow;
             row.LastModifiedAcceptRejectBy = userName;


### PR DESCRIPTION
Sets reason to null in database if you had a previously rejected billing instruction and now accepting it, I would accept the reason to change to null