### PR TITLE
Fixes Msg 207 compile-time failure in BillingRunStatus migration

### DIFF
--- a/src/EPR.Calculator.API.Data/Migrations/20260603161538_BillingRunStatus.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20260603161538_BillingRunStatus.cs
@@ -128,16 +128,17 @@ namespace EPR.Calculator.API.Data.Migrations
 
             // Remaining runs with is_billing_file_generating=true:
             // Set billing_run_status=Errored
+            // Wrapped in EXEC() so SQL Server defers column name resolution to runtime.
+            // is_billing_file_generating is dropped later in this migration; without EXEC()
+            // the IF NOT EXISTS guard in the generated script does not protect against
+            // Msg 207 (invalid column name) because SQL Server validates DML column
+            // references at compile time, before evaluating the IF condition.
             migrationBuilder.Sql("""
-                UPDATE
-                    run
-                SET
-                    run.billing_run_status = 'Errored'
-                FROM
-                    dbo.calculator_run AS run
-                WHERE
-                    run.billing_run_status IS NULL AND
-                    run.is_billing_file_generating = 1
+                EXEC(N'UPDATE run
+                SET run.billing_run_status = ''Errored''
+                FROM dbo.calculator_run AS run
+                WHERE run.billing_run_status IS NULL
+                AND run.is_billing_file_generating = 1')
                 """);
 
             // Remaining runs with IN_THE_QUEUE/RUNNING/UNCLASSIFIED/TEST_RUN/ERROR/DELETED run status:

--- a/src/EPR.Calculator.API.Data/Scripts/migrations.sql
+++ b/src/EPR.Calculator.API.Data/Scripts/migrations.sql
@@ -8008,15 +8008,11 @@ IF NOT EXISTS (
     WHERE [MigrationId] = N'20260603161538_BillingRunStatus'
 )
 BEGIN
-    UPDATE
-        run
-    SET
-        run.billing_run_status = 'Errored'
-    FROM
-        dbo.calculator_run AS run
-    WHERE
-        run.billing_run_status IS NULL AND
-        run.is_billing_file_generating = 1
+    EXEC(N'UPDATE run
+    SET run.billing_run_status = ''Errored''
+    FROM dbo.calculator_run AS run
+    WHERE run.billing_run_status IS NULL
+    AND run.is_billing_file_generating = 1')
 END;
 GO
 


### PR DESCRIPTION
SQL Server validates DML column references at batch compile time, before
evaluating IF NOT EXISTS guards. is_billing_file_generating is dropped
later in this migration, so on databases where the migration has already
been applied the guarded UPDATE causes Msg 207 (invalid column name) at
parse time, aborting sqlcmd and blocking all subsequent migrations.

Wrap the UPDATE in EXEC() so column name resolution is deferred to
runtime, by which point the IF condition has already short-circuited
the batch. migrations.sql regenerated from the updated migration.
