### PR TITLE
ECV-591 - Add cost data and cancelled producer tables in order to read back for billing runs

### DIFF
--- a/src/EPR.Calculator.API.Data/ApplicationDBContext.cs
+++ b/src/EPR.Calculator.API.Data/ApplicationDBContext.cs
@@ -56,6 +56,13 @@ public class ApplicationDBContext : DbContext
     public DbSet<CalculatorRunRelativeYear> CalculatorRunRelativeYears { get; set; }
     public DbSet<CalculatorRunBillingFileMetadata> CalculatorRunBillingFileMetadata { get; set; }
     public DbSet<ErrorReport> ErrorReports { get; set; }
+    public DbSet<CalcResultLapcapDataEntry> LapcapData { get; set; }
+    public DbSet<CalcResultCommsCostEntry> CommCost { get; set; }
+    public DbSet<CalcResultLateReportingTonnageEntry> LateReportingTonnage { get; set; }
+    public DbSet<CalcResultParameterOtherCostEntry> ParameterOtherCost { get; set; }
+    public DbSet<CalcResultOnePlusFourApportionmentEntry> OnePlusFourApportionment { get; set; }
+    public DbSet<CalcResultLaDisposalCostDataEntry> LaDisposalCostData { get; set; }
+    public DbSet<CalcResultCancelledProducerEntry> CancelledProducers { get; set; }
 
     public async Task<RelativeYear?> FindRelativeYearAsync(int value, CancellationToken cancellationToken = default)
     {

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultCancelledProducers.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultCancelledProducers.cs
@@ -1,0 +1,39 @@
+namespace EPR.Calculator.API.Data.DataModels;
+
+
+public class CalcResultCancelledProducerEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultCancelledProducer CancelledProducer { get; set; }
+}
+
+public class CalcResultCancelledProducer
+{
+    public int ProducerId { get; set; }
+    public string? SubsidiaryId { get; set; }
+    public string? ProducerOrSubsidiaryName { get; set; }
+    public string? TradingName { get; set; }
+    public LastTonnage? LastTonnage { get; set; }
+    public LatestInvoice? LatestInvoice { get; set; }
+}
+
+public class LastTonnage
+{
+    public decimal? Aluminium { get; set; }
+    public decimal? FibreComposite { get; set; }
+    public decimal? Glass { get; set; }
+    public decimal? PaperOrCard { get; set; }
+    public decimal? Plastic { get; set; }
+    public decimal? Steel { get; set; }
+    public decimal? Wood { get; set; }
+    public decimal? OtherMaterials { get; set; }
+}
+
+public class LatestInvoice
+{
+    public decimal? CurrentYearInvoicedTotalToDate { get; set; }
+    public string? RunNumber { get; set; }
+    public string? RunName { get; set; }
+    public string? BillingInstructionId { get; set; }
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultCommsCost.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultCommsCost.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations.Schema;
+using EPR.Calculator.API.Data.Utils;
+
+namespace EPR.Calculator.API.Data.DataModels;
+
+public class CalcResultCommsCostEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultCommsCost CommsCost { get; set; }
+}
+
+public class CalcResultCommsCost
+{
+    public required ByCountryApportionment OnePlusFourApportionment { get; set; }
+
+    internal ICollection<MaterialCommsCostData> MaterialCosts { get; set; } = [];
+
+    [NotMapped]
+    public required IReadOnlyDictionary<string, CalcResultCommsCostCommsCostByMaterial> ByMaterial
+    {
+        get => MaterialCosts.ToDictionary(x => x.MaterialCode, x => x.CommsCost);
+        init => MaterialCosts = [..value.Select(kvp =>
+            new MaterialCommsCostData { MaterialCode = kvp.Key, CommsCost = kvp.Value })];
+    }
+
+    private CalcResultCommsCostCommsCostByMaterial? total;
+    public CalcResultCommsCostCommsCostByMaterial Total =>
+        total ??=
+            new CalcResultCommsCostCommsCostByMaterial
+            {
+                Cost                             = ByCountryCost.Sum(ByMaterial.Values.Select(v => v.Cost).ToImmutableList()),
+                TotalCost                        = ByMaterial.Values.Sum(v => v.TotalCost),
+                // TODO why do we sum up tonnage for different materials?
+                HouseholdPackagingWasteTonnage   = ByMaterial.Values.Sum(v => v.HouseholdPackagingWasteTonnage),
+                PublicBinTonnage                 = ByMaterial.Values.Sum(v => v.PublicBinTonnage),
+                HouseholdDrinksContainersTonnage = ByMaterial.Values.Sum(v => v.HouseholdDrinksContainersTonnage),
+                LateReportingTonnage             = ByMaterial.Values.Sum(v => v.LateReportingTonnage)
+            };
+
+    public required ByCountryCost CommsCostUkWide { get; set; }
+
+    public required ByCountryCost CommsCostByCountry { get; set; }
+}
+
+public class CalcResultCommsCostCommsCostByMaterial
+{
+    public required ByCountryCost Cost {get; set;}
+
+    /// <summary>
+    /// The pre-apportionment total cost for this material. Used for PricePerTonne so that
+    /// floating-point rounding across the four country splits does not alter the result.
+    /// </summary>
+    public required decimal TotalCost { get; set; }
+
+    public required decimal HouseholdPackagingWasteTonnage { get; set; }
+    public required decimal PublicBinTonnage { get; set; }
+    public required decimal HouseholdDrinksContainersTonnage { get; set; }
+    public required decimal LateReportingTonnage { get; set; }
+
+    private decimal? totalTonnage;
+    public decimal TotalTonnage =>
+        totalTonnage ??=
+            HouseholdPackagingWasteTonnage
+            + LateReportingTonnage
+            + PublicBinTonnage
+            + HouseholdDrinksContainersTonnage;
+
+    private decimal? pricePerTonne;
+    public decimal PricePerTonne =>
+        pricePerTonne ??=
+            TotalTonnage != 0 ? MathUtils.RoundAwayFromZero(TotalCost / TotalTonnage, 4) : 0;
+}
+
+internal record MaterialCommsCostData
+{
+    public required string MaterialCode { get; set; }
+    public required CalcResultCommsCostCommsCostByMaterial CommsCost { get; set; }
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultLaDisposalCostData.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultLaDisposalCostData.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations.Schema;
+using EPR.Calculator.API.Data.Utils;
+
+namespace EPR.Calculator.API.Data.DataModels;
+
+public class CalcResultLaDisposalCostDataEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultLaDisposalCostData LaDisposalCost { get; set; }
+
+}
+
+public class CalcResultLaDisposalCostData
+{
+    internal ICollection<MaterialLaDisposalCostData> MaterialCosts { get; set; } = [];
+
+    [NotMapped]
+    public required IReadOnlyDictionary<string, CalcResultLaDisposalCostDataDetail> ByMaterial
+    {
+        get => MaterialCosts.ToDictionary(x => x.MaterialCode, x => x.Detail);
+        init => MaterialCosts = [..value.Select(kvp =>
+            new MaterialLaDisposalCostData { MaterialCode = kvp.Key, Detail = kvp.Value })];
+    }
+
+    private CalcResultLaDisposalCostDataDetail? total;
+    public CalcResultLaDisposalCostDataDetail Total =>
+        total ??=
+            new CalcResultLaDisposalCostDataDetail
+            {
+                Cost                                    = ByCountryCost.Sum(ByMaterial.Values.Select(v => v.Cost).ToImmutableList()),
+                // TODO why do we sum up tonnage for different materials?
+                HouseholdPackagingWasteTonnage          = ByMaterial.Values.Sum(v => v.HouseholdPackagingWasteTonnage),
+                PublicBinTonnage                        = ByMaterial.Values.Sum(v => v.PublicBinTonnage),
+                HouseholdDrinkContainersTonnage         = ByMaterial.Values.Sum(v => v.HouseholdDrinkContainersTonnage),
+                LateReportingTonnage                    = ByMaterial.Values.Sum(v => v.LateReportingTonnage),
+                ActionedSelfManagedConsumerWasteTonnage = ByMaterial.Values.Sum(v => v.ActionedSelfManagedConsumerWasteTonnage ?? 0)
+            };
+}
+
+internal record MaterialLaDisposalCostData
+{
+    public required string MaterialCode { get; set; }
+    public required CalcResultLaDisposalCostDataDetail Detail { get; set; }
+}
+
+public class CalcResultLaDisposalCostDataDetail
+{
+    public required ByCountryCost Cost { get; init; }
+
+    public required decimal HouseholdPackagingWasteTonnage { get; init; }
+
+    public required decimal PublicBinTonnage { get; init; }
+
+    public required decimal HouseholdDrinkContainersTonnage { get; init; }
+
+    public decimal LateReportingTonnage { get; init; }
+
+    // This will be null for Pre-Modulation - i.e. isn't part of the calculation
+    public decimal? ActionedSelfManagedConsumerWasteTonnage { get; init; }
+
+    private decimal? totalTonnage;
+    public decimal TotalTonnage =>
+        totalTonnage ??=
+            LateReportingTonnage
+                + HouseholdPackagingWasteTonnage
+                + PublicBinTonnage
+                + HouseholdDrinkContainersTonnage
+                - (ActionedSelfManagedConsumerWasteTonnage ?? 0);
+
+    private decimal? disposalCostPricePerTonne;
+    public decimal? DisposalCostPricePerTonne =>
+        disposalCostPricePerTonne ??=
+            TotalTonnage == 0 ? (decimal?)null : MathUtils.RoundAwayFromZero(Cost.Total / TotalTonnage, 4);
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultLapcapData.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultLapcapData.cs
@@ -1,0 +1,53 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EPR.Calculator.API.Data.DataModels;
+
+public class CalcResultLapcapDataEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultLapcapData LapcapData { get; set; }
+}
+
+public class CalcResultLapcapData
+{
+    internal ICollection<MaterialLapcapData> MaterialCosts { get; set; } = [];
+
+    [NotMapped]
+    public required IReadOnlyDictionary<string, ByCountryCost> ByMaterial
+    {
+        get => MaterialCosts.ToDictionary(x => x.MaterialCode, x => x.Cost);
+        init => MaterialCosts = [..value.Select(kvp =>
+            new MaterialLapcapData { MaterialCode = kvp.Key, Cost = kvp.Value })];
+    }
+
+    private ByCountryCost? total;
+    public ByCountryCost Total =>
+        total ??=
+            new ByCountryCost
+            {
+                England         = ByMaterial.Values.Sum(x => x.England),
+                NorthernIreland = ByMaterial.Values.Sum(x => x.NorthernIreland),
+                Scotland        = ByMaterial.Values.Sum(x => x.Scotland),
+                Wales           = ByMaterial.Values.Sum(x => x.Wales)
+            };
+
+    private ByCountryApportionment? countryApportionment;
+    public ByCountryApportionment CountryApportionment =>
+        countryApportionment ??=
+            Total.Total == 0
+            ? ByCountryApportionment.Empty
+            : new ByCountryApportionment
+            {
+                England         = Total.England         / Total.Total * 100,
+                Wales           = Total.Wales           / Total.Total * 100,
+                Scotland        = Total.Scotland        / Total.Total * 100,
+                NorthernIreland = Total.NorthernIreland / Total.Total * 100
+            };
+}
+
+internal record MaterialLapcapData
+{
+    public required string MaterialCode { get; set; }
+    public required ByCountryCost Cost { get; set; }
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultLateReportingTonnage.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultLateReportingTonnage.cs
@@ -1,0 +1,52 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EPR.Calculator.API.Data.DataModels;
+
+public record CalcResultLateReportingTonnageEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultLateReportingTonnage LateReportingTonnage { get; set; }
+
+}
+
+public record CalcResultLateReportingTonnage
+{
+    internal ICollection<MaterialLateReportingTonnageData> MaterialTonnages { get; set; } = [];
+
+    [NotMapped]
+    public required IReadOnlyDictionary<string, CalcResultLateReportingTonnageDetail> ByMaterial
+    {
+        get => MaterialTonnages.ToDictionary(x => x.MaterialCode, x => x.Detail);
+        init => MaterialTonnages = [..value.Select(kvp =>
+            new MaterialLateReportingTonnageData { MaterialCode = kvp.Key, Detail = kvp.Value })];
+    }
+
+    private CalcResultLateReportingTonnageDetail? total;
+    public CalcResultLateReportingTonnageDetail Total =>
+        total ??=
+            new CalcResultLateReportingTonnageDetail
+            {
+                 Total = ByMaterial.Values.Sum(v => v.Total),
+                 Red   = ByMaterial.Values.Sum(v => v.Red),
+                 Amber = ByMaterial.Values.Sum(v => v.Amber),
+                 Green = ByMaterial.Values.Sum(v => v.Green)
+            };
+}
+
+internal record MaterialLateReportingTonnageData
+{
+    public required string MaterialCode { get; set; }
+    public required CalcResultLateReportingTonnageDetail Detail { get; set; }
+}
+
+public record CalcResultLateReportingTonnageDetail
+{
+    required public decimal Total { get; init; }
+
+    required public decimal Red { get; init; }
+
+    required public decimal Amber { get; init; }
+
+    required public decimal Green { get; init; }
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultOnePlusFourApportionment.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultOnePlusFourApportionment.cs
@@ -1,0 +1,40 @@
+﻿namespace EPR.Calculator.API.Data.DataModels;
+
+public class CalcResultOnePlusFourApportionmentEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultOnePlusFourApportionment OnePlusFourApportionment { get; set; }
+
+}
+
+public class CalcResultOnePlusFourApportionment
+{
+    public required ByCountryCost LaDisposalCost { get; init; }
+    public required ByCountryCost LADataPrepCharge { get; init; }
+
+    private ByCountryCost? totalOnePlusFour;
+    public ByCountryCost TotalOnePlusFour =>
+        totalOnePlusFour ??=
+            new ByCountryCost
+            {
+                England         = LaDisposalCost.England         + LADataPrepCharge.England,
+                Wales           = LaDisposalCost.Wales           + LADataPrepCharge.Wales,
+                Scotland        = LaDisposalCost.Scotland        + LADataPrepCharge.Scotland,
+                NorthernIreland = LaDisposalCost.NorthernIreland + LADataPrepCharge.NorthernIreland
+            };
+
+    private ByCountryApportionment? onePlusFourApportionment;
+    public ByCountryApportionment OnePlusFourApportionment =>
+        onePlusFourApportionment ??=
+            TotalOnePlusFour.Total == 0
+            ? ByCountryApportionment.Empty
+            : new ByCountryApportionment
+                {
+                    England         = 100 * TotalOnePlusFour.England         / TotalOnePlusFour.Total,
+                    Wales           = 100 * TotalOnePlusFour.Wales           / TotalOnePlusFour.Total,
+                    Scotland        = 100 * TotalOnePlusFour.Scotland        / TotalOnePlusFour.Total,
+                    NorthernIreland = 100 * TotalOnePlusFour.NorthernIreland / TotalOnePlusFour.Total,
+                };
+
+}

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultParameterOtherCost.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultParameterOtherCost.cs
@@ -18,6 +18,7 @@ public class CalcResultParameterOtherCost
     public Materiality TonnageChangeIncrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
     public Materiality TonnageChangeDecrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
     public decimal BadDebtValue { get; set; }
+    public DateTime? CutOffDate { get; set; }
 }
 
 public record Materiality

--- a/src/EPR.Calculator.API.Data/DataModels/CalcResultParameterOtherCost.cs
+++ b/src/EPR.Calculator.API.Data/DataModels/CalcResultParameterOtherCost.cs
@@ -1,0 +1,27 @@
+﻿namespace EPR.Calculator.API.Data.DataModels;
+
+public class CalcResultParameterOtherCostEntry
+{
+    public int Id { get; set; }
+    public required int CalculatorRunId { get; set; }
+    public required CalcResultParameterOtherCost ParameterOtherCost { get; set; }
+}
+
+public class CalcResultParameterOtherCost
+{
+    public ByCountryCost SaOperatingCost { get; set; } = ByCountryCost.Empty;
+    public ByCountryCost LaDataPrepCharge { get; set; } = ByCountryCost.Empty;
+    public ByCountryApportionment CountryApportionment { get; set; } = ByCountryApportionment.Empty;
+    public ByCountryCost SchemeSetupCost { get; set; } = ByCountryCost.Empty;
+    public Materiality MaterialityIncrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
+    public Materiality MaterialityDecrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
+    public Materiality TonnageChangeIncrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
+    public Materiality TonnageChangeDecrease { get; set; } = new Materiality { Amount = 0, Percentage = 0 };
+    public decimal BadDebtValue { get; set; }
+}
+
+public record Materiality
+{
+    public required decimal Amount  { get; init; }
+    public required decimal Percentage { get; init; }
+}

--- a/src/EPR.Calculator.API.Data/EPR.Calculator.API.Data.csproj
+++ b/src/EPR.Calculator.API.Data/EPR.Calculator.API.Data.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SonarQubeExclude>true</SonarQubeExclude>

--- a/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.Designer.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.Designer.cs
@@ -4,6 +4,7 @@ using EPR.Calculator.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.Calculator.API.Data.Migrations
 {
     [DbContext(typeof(ApplicationDBContext))]
-    partial class ApplicationDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260722145707_AddCostDataAndCancelledProducerTables")]
+    partial class AddCostDataAndCancelledProducerTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -801,10 +804,9 @@ namespace EPR.Calculator.API.Data.Migrations
                         .HasColumnType("nvarchar(450)")
                         .HasColumnName("parameter_unique_ref");
 
-                    b.Property<string>("ParameterValue")
-                        .IsRequired()
+                    b.Property<decimal>("ParameterValue")
                         .HasPrecision(18, 3)
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("decimal(18,3)")
                         .HasColumnName("parameter_value");
 
                     b.HasKey("Id");
@@ -1359,14 +1361,6 @@ namespace EPR.Calculator.API.Data.Migrations
                             ParameterType = "Red modulation factor",
                             ValidRangeFrom = 1.000m,
                             ValidRangeTo = 2.000m
-                        },
-                        new
-                        {
-                            ParameterUniqueReferenceId = "COFF-DT",
-                            ParameterCategory = "Optional Date",
-                            ParameterType = "Cut-off date",
-                            ValidRangeFrom = 0m,
-                            ValidRangeTo = 0m
                         });
                 });
 

--- a/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.Designer.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.Designer.cs
@@ -804,9 +804,10 @@ namespace EPR.Calculator.API.Data.Migrations
                         .HasColumnType("nvarchar(450)")
                         .HasColumnName("parameter_unique_ref");
 
-                    b.Property<decimal>("ParameterValue")
-                        .HasPrecision(18, 3)
-                        .HasColumnType("decimal(18,3)")
+                    b.Property<string>("ParameterValue")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)")
                         .HasColumnName("parameter_value");
 
                     b.HasKey("Id");
@@ -1361,6 +1362,14 @@ namespace EPR.Calculator.API.Data.Migrations
                             ParameterType = "Red modulation factor",
                             ValidRangeFrom = 1.000m,
                             ValidRangeTo = 2.000m
+                        },
+                        new
+                        {
+                            ParameterUniqueReferenceId = "COFF-DT",
+                            ParameterCategory = "Optional Date",
+                            ParameterType = "Cut-off date",
+                            ValidRangeFrom = 0m,
+                            ValidRangeTo = 0m
                         });
                 });
 
@@ -4026,6 +4035,9 @@ namespace EPR.Calculator.API.Data.Migrations
                             b1.Property<decimal>("BadDebtValue")
                                 .HasPrecision(18, 6)
                                 .HasColumnType("decimal(18,6)");
+
+                            b1.Property<DateTime?>("CutOffDate")
+                                .HasColumnType("datetime2");
 
                             b1.HasKey("CalcResultParameterOtherCostEntryId");
 

--- a/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/20260722145707_AddCostDataAndCancelledProducerTables.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EPR.Calculator.API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCostDataAndCancelledProducerTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "calc_result_cancelled_producer",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    cancelled_producer = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_cancelled_producer", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_comms_cost",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    comms_cost = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_comms_cost", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_la_disposal_cost",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    la_disposal_cost = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_la_disposal_cost", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_lapcap_data",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    lapcap = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_lapcap_data", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_late_reporting_tonnage",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    late_reporting_tonnage = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_late_reporting_tonnage", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_one_plus_four_apportionment",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    one_plus_four_apppointment = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_one_plus_four_apportionment", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "calc_result_parameter_other_cost",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    calculator_run_id = table.Column<int>(type: "int", nullable: false),
+                    parameter_other_cost = table.Column<string>(type: "json", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_calc_result_parameter_other_cost", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_calc_result_cancelled_producer_calculator_run_id",
+                table: "calc_result_cancelled_producer",
+                column: "calculator_run_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "calc_result_cancelled_producer");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_comms_cost");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_la_disposal_cost");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_lapcap_data");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_late_reporting_tonnage");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_one_plus_four_apportionment");
+
+            migrationBuilder.DropTable(
+                name: "calc_result_parameter_other_cost");
+        }
+    }
+}

--- a/src/EPR.Calculator.API.Data/Migrations/ApplicationDBContextModelSnapshot.cs
+++ b/src/EPR.Calculator.API.Data/Migrations/ApplicationDBContextModelSnapshot.cs
@@ -803,8 +803,8 @@ namespace EPR.Calculator.API.Data.Migrations
 
                     b.Property<string>("ParameterValue")
                         .IsRequired()
-                        .HasPrecision(18, 3)
-                        .HasColumnType("nvarchar(max)")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)")
                         .HasColumnName("parameter_value");
 
                     b.HasKey("Id");
@@ -4032,6 +4032,9 @@ namespace EPR.Calculator.API.Data.Migrations
                             b1.Property<decimal>("BadDebtValue")
                                 .HasPrecision(18, 6)
                                 .HasColumnType("decimal(18,6)");
+
+                            b1.Property<DateTime?>("CutOffDate")
+                                .HasColumnType("datetime2");
 
                             b1.HasKey("CalcResultParameterOtherCostEntryId");
 

--- a/src/EPR.Calculator.API.Data/Scripts/migrations.sql
+++ b/src/EPR.Calculator.API.Data/Scripts/migrations.sql
@@ -8854,3 +8854,126 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_cancelled_producer] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [cancelled_producer] json NOT NULL,
+        CONSTRAINT [PK_calc_result_cancelled_producer] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_comms_cost] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [comms_cost] json NOT NULL,
+        CONSTRAINT [PK_calc_result_comms_cost] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_la_disposal_cost] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [la_disposal_cost] json NOT NULL,
+        CONSTRAINT [PK_calc_result_la_disposal_cost] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_lapcap_data] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [lapcap] json NOT NULL,
+        CONSTRAINT [PK_calc_result_lapcap_data] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_late_reporting_tonnage] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [late_reporting_tonnage] json NOT NULL,
+        CONSTRAINT [PK_calc_result_late_reporting_tonnage] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_one_plus_four_apportionment] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [one_plus_four_apppointment] json NOT NULL,
+        CONSTRAINT [PK_calc_result_one_plus_four_apportionment] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE TABLE [calc_result_parameter_other_cost] (
+        [id] int NOT NULL IDENTITY,
+        [calculator_run_id] int NOT NULL,
+        [parameter_other_cost] json NOT NULL,
+        CONSTRAINT [PK_calc_result_parameter_other_cost] PRIMARY KEY ([id])
+    );
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    CREATE INDEX [IX_calc_result_cancelled_producer_calculator_run_id] ON [calc_result_cancelled_producer] ([calculator_run_id]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20260722145707_AddCostDataAndCancelledProducerTables'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20260722145707_AddCostDataAndCancelledProducerTables', N'8.0.7');
+END;
+GO
+
+COMMIT;
+GO
+

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultCancelledProducersConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultCancelledProducersConfiguration.cs
@@ -1,0 +1,27 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultCancelledProducersConfiguration : IEntityTypeConfiguration<CalcResultCancelledProducerEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultCancelledProducerEntry> builder)
+    {
+        builder.ToTable("calc_result_cancelled_producer");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.CancelledProducer, o =>
+        {
+            o.ToJson("cancelled_producer");
+            o.OwnsOne(x => x.LastTonnage);
+            o.OwnsOne(x => x.LatestInvoice);
+        });
+
+        builder.HasIndex(x => x.CalculatorRunId);
+
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultCommsCostConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultCommsCostConfiguration.cs
@@ -1,0 +1,35 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultCommsCostConfiguration : IEntityTypeConfiguration<CalcResultCommsCostEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultCommsCostEntry> builder)
+    {
+        builder.ToTable("calc_result_comms_cost");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.CommsCost, o =>
+        {
+            o.ToJson("comms_cost");
+
+            o.OwnsOne(x => x.OnePlusFourApportionment, a => a.Ignore(p => p.Total));
+
+            o.OwnsMany(x => x.MaterialCosts, a =>
+            {
+                a.Property(x => x.MaterialCode);
+                a.OwnsOne(x => x.CommsCost, c => c.OwnsOne(x => x.Cost, d => d.Ignore(p => p.Total)));
+            });
+
+            o.OwnsOne(x => x.CommsCostUkWide, a => a.Ignore(p => p.Total));
+            o.OwnsOne(x => x.CommsCostByCountry, a => a.Ignore(p => p.Total));
+
+            o.Ignore(x => x.Total);
+        });
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLaDisposalCostDataConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLaDisposalCostDataConfiguration.cs
@@ -1,0 +1,31 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultLaDisposalCostDataConfiguration : IEntityTypeConfiguration<CalcResultLaDisposalCostDataEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultLaDisposalCostDataEntry> builder)
+    {
+        builder.ToTable("calc_result_la_disposal_cost");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.LaDisposalCost, o =>
+        {
+            o.ToJson("la_disposal_cost");
+
+            o.OwnsMany(x => x.MaterialCosts, a =>
+            {
+                a.Property(x => x.MaterialCode);
+                a.OwnsOne(x => x.Detail, c => c.OwnsOne(x => x.Cost, d => d.Ignore(p => p.Total)));
+            });
+
+            o.Ignore(x => x.Total);
+        });
+
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLapcapDataConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLapcapDataConfiguration.cs
@@ -1,0 +1,31 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultLapcapDataConfiguration : IEntityTypeConfiguration<CalcResultLapcapDataEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultLapcapDataEntry> builder)
+    {
+        builder.ToTable("calc_result_lapcap_data");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.LapcapData, o =>
+        {
+            o.ToJson("lapcap");
+
+            o.OwnsMany(x => x.MaterialCosts, a =>
+            {
+                a.Property(x => x.MaterialCode);
+                a.OwnsOne(x => x.Cost, c => c.Ignore(p => p.Total));
+            });
+
+            o.Ignore(x => x.Total);
+            o.Ignore(x => x.CountryApportionment);
+        });
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLateReportingTonnageConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultLateReportingTonnageConfiguration.cs
@@ -1,0 +1,30 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultLateReportingTonnageConfiguration : IEntityTypeConfiguration<CalcResultLateReportingTonnageEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultLateReportingTonnageEntry> builder)
+    {
+        builder.ToTable("calc_result_late_reporting_tonnage");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.LateReportingTonnage, o =>
+        {
+            o.ToJson("late_reporting_tonnage");
+
+            o.OwnsMany(x => x.MaterialTonnages, a =>
+            {
+                a.Property(x => x.MaterialCode);
+                a.OwnsOne(x => x.Detail);
+            });
+
+            o.Ignore(x => x.Total);
+        });
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultOnePlusFourApportionmentConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultOnePlusFourApportionmentConfiguration.cs
@@ -1,0 +1,26 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultOnePlusFourApportionmentConfiguration : IEntityTypeConfiguration<CalcResultOnePlusFourApportionmentEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultOnePlusFourApportionmentEntry> builder)
+    {
+        builder.ToTable("calc_result_one_plus_four_apportionment");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+
+        builder.OwnsOne(x => x.OnePlusFourApportionment, o =>
+        {
+            o.ToJson("one_plus_four_apppointment");
+            o.OwnsOne(x => x.LaDisposalCost, a => a.Ignore(p => p.Total));
+            o.OwnsOne(x => x.LADataPrepCharge, a => a.Ignore(p => p.Total));
+            o.Ignore(x => x.TotalOnePlusFour);
+            o.Ignore(x => x.OnePlusFourApportionment);
+        });
+    }
+}

--- a/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultParameterOtherCostConfiguration.cs
+++ b/src/EPR.Calculator.API.Data/TypeConfigurations/CalcResultParameterOtherCostConfiguration.cs
@@ -1,0 +1,30 @@
+using EPR.Calculator.API.Data.DataModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EPR.Calculator.API.Data.TypeConfigurations;
+
+public class CalcResultParameterOtherCostConfiguration : IEntityTypeConfiguration<CalcResultParameterOtherCostEntry>
+{
+    public void Configure(EntityTypeBuilder<CalcResultParameterOtherCostEntry> builder)
+    {
+        builder.ToTable("calc_result_parameter_other_cost");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(x => x.CalculatorRunId).HasColumnName("calculator_run_id").IsRequired();
+        
+        builder.OwnsOne(x => x.ParameterOtherCost, o =>
+        {
+            o.ToJson("parameter_other_cost");
+            o.OwnsOne(x => x.SaOperatingCost, y => y.Ignore(p => p.Total));
+            o.OwnsOne(x => x.LaDataPrepCharge, y => y.Ignore(p => p.Total));
+            o.OwnsOne(x => x.CountryApportionment, y => y.Ignore(p => p.Total));
+            o.OwnsOne(x => x.SchemeSetupCost, y => y.Ignore(p => p.Total));
+            o.OwnsOne(x => x.MaterialityIncrease);
+            o.OwnsOne(x => x.MaterialityDecrease);
+            o.OwnsOne(x => x.TonnageChangeIncrease);
+            o.OwnsOne(x => x.TonnageChangeDecrease);
+        });
+    }
+}

--- a/src/EPR.Calculator.API.Data/Utils/MathUtils.cs
+++ b/src/EPR.Calculator.API.Data/Utils/MathUtils.cs
@@ -1,0 +1,7 @@
+namespace EPR.Calculator.API.Data.Utils;
+
+public static class MathUtils
+{
+    public static decimal RoundAwayFromZero(decimal value, int decimals = 0) =>
+        Math.Round(value, decimals, MidpointRounding.AwayFromZero);
+}


### PR DESCRIPTION
Moves/refactors data models existing in epr-calculator-service.
Creates tables for these, where they are stored as JSON - allowing us to store these during result file runs to be read back during billing file runs rather than recalculating them again.