### PR TITLE
ECV-681 Add thousand separators (commas) to £ cost and tonnage values…

### DIFF
--- a/src/EPR.Calculator.API.UnitTests/Validators/CreateDefaultParameterDataValidatorTest.cs
+++ b/src/EPR.Calculator.API.UnitTests/Validators/CreateDefaultParameterDataValidatorTest.cs
@@ -220,14 +220,14 @@ namespace EPR.Calculator.API.UnitTests.Validators
                 new[]
                 {
 
-                    "The parameter COMC-AL must be between £0 and £999999999.99.",
+                    "The parameter COMC-AL must be between £0.00 and £999,999,999.99.",
                     "The parameter BADEBT-P must be between 0% and 999.99%.",
-                    "The parameter MATT-AD must be between £-999999999.99 and £0.",
+                    "The parameter MATT-AD must be between -£999,999,999.99 and £0.00.",
                     "The parameter MATT-PI must be between 0% and 999.99%.",
                     "The parameter MATT-PD must be between -999.99% and 0%.",
-                    "The parameter TONT-AI must be between £0 and £999999999.99.",
+                    "The parameter TONT-AI must be between £0.00 and £999,999,999.99.",
                     "The parameter REDM-RF must be between 1.000 and 2.000.",
-                    "The parameter LRET-AL must be between 0 and 999999999.999 tons."
+                    "The parameter LRET-AL must be between 0 and 999,999,999.999 tons."
                 },
                 Validator.Validate(dto).Errors.Select(x => x.Message).ToList());
         }

--- a/src/EPR.Calculator.API/Validators/CreateDefaultParameterDataValidator.cs
+++ b/src/EPR.Calculator.API/Validators/CreateDefaultParameterDataValidator.cs
@@ -113,30 +113,37 @@ public class CreateDefaultParameterDataValidator(ApplicationDBContext context) :
 
     private static string OutOfRangeValues(DefaultParameterTemplateMaster master)
     {
-        var id   = master.ParameterUniqueReferenceId;
-        var from = master.ValidRangeFrom;
-        var to   = master.ValidRangeTo;
+        var id  = master.ParameterUniqueReferenceId;
 
         if (IsTonnage(master))
         {
-            return $"The parameter {id} must be between {decimal.Truncate(from)} and {Math.Round(to, 3, MidpointRounding.ToZero)} tons.";
-
+            var min = decimal.Truncate(master.ValidRangeFrom);
+            var max = Math.Round(master.ValidRangeTo, 3, MidpointRounding.ToZero).ToString("N3");
+            return $"The parameter {id} must be between {min} and {max} tons.";
         }
         else if (IsBadDebt(master) || IsPercentageIncrease(master))
         {
-            return $"The parameter {id} must be between {decimal.Truncate(from)}% and {Math.Round(to, 2, MidpointRounding.ToZero)}%.";
+            var min = decimal.Truncate(master.ValidRangeFrom);
+            var max = Math.Round(master.ValidRangeTo, 2, MidpointRounding.ToZero);
+            return $"The parameter {id} must be between {min}% and {max}%.";
         }
         else if (IsPercentageDecrease(master))
         {
-            return $"The parameter {id} must be between {Math.Round(from, 2, MidpointRounding.ToZero)}% and {decimal.Truncate(to)}%.";
+            var min = Math.Round(master.ValidRangeFrom, 2, MidpointRounding.ToZero);
+            var max = decimal.Truncate(master.ValidRangeTo);
+            return $"The parameter {id} must be between {min}% and {max}%.";
         }
         else if (IsFactor(master))
         {
-            return $"The parameter {id} must be between {Math.Round(from, 3, MidpointRounding.ToZero)} and {Math.Round(to, 3, MidpointRounding.ToZero)}.";
+            var min = Math.Round(master.ValidRangeFrom, 3, MidpointRounding.ToZero);
+            var max = Math.Round(master.ValidRangeTo  , 3, MidpointRounding.ToZero);
+            return $"The parameter {id} must be between {min} and {max}.";
         }
         else
         {
-            return $"The parameter {id} must be between £{Math.Round(from, 2, MidpointRounding.ToZero)} and £{Math.Round(to, 2, MidpointRounding.ToZero)}.";
+            var min = Math.Round(master.ValidRangeFrom, 2, MidpointRounding.ToZero).ToString("C");
+            var max = Math.Round(master.ValidRangeTo  , 2, MidpointRounding.ToZero).ToString("C");
+            return $"The parameter {id} must be between {min} and {max}.";
         }
     }
 


### PR DESCRIPTION
Small change to improve default parameter min and max range validation error messages readability, as requested by content design.

Custom format used instead of "C" to omit unnecessary decimal places (e.g. £0 instead of £0.00).