### PR TITLE
ECV-686: Removes UTF-16 re-encode when downloading from BlobStorage

### DIFF
--- a/src/EPR.Calculator.API.BackgroundService.UnitTests/Features/Billing/FileExports/BillingFileExporterTests.cs
+++ b/src/EPR.Calculator.API.BackgroundService.UnitTests/Features/Billing/FileExports/BillingFileExporterTests.cs
@@ -42,11 +42,11 @@ public class BillingFileGeneratorTests : TestsFor<BillingFileGenerator>
 
         storageUploadService = fixture.Freeze<Mock<IStorageUploadService>>();
         storageUploadService.Setup(m => m.UploadFileContentAsync(
-                It.Is<(string, string, string, string, bool)>(a => a.Item4 == "csv-container"),
+                It.Is<IStorageUploadService.Request>(a => a.ContainerName == "csv-container"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("https://csv.uri");
         storageUploadService.Setup(m => m.UploadFileContentAsync(
-                It.Is<(string, string, string, string, bool)>(a => a.Item4 == "json-container"),
+                It.Is<IStorageUploadService.Request>(a => a.ContainerName == "json-container"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("https://json.uri");
 
@@ -62,11 +62,11 @@ public class BillingFileGeneratorTests : TestsFor<BillingFileGenerator>
 
         // Assert
         storageUploadService.Verify(x => x.UploadFileContentAsync(
-            It.Is<(string FileName, string Content, string RunName, string ContainerName, bool Overwrite)>(args =>
+            It.Is<IStorageUploadService.Request>(args =>
                 args.Content == "csv-content"
-                && args.RunName == runContext.RunName
                 && args.ContainerName == "csv-container"
-                && args.Overwrite),
+                && args.Overwrite
+                && args.UseUtf8Bom),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -78,11 +78,11 @@ public class BillingFileGeneratorTests : TestsFor<BillingFileGenerator>
 
         // Assert
         storageUploadService.Verify(x => x.UploadFileContentAsync(
-            It.Is<(string FileName, string Content, string RunName, string ContainerName, bool Overwrite)>(args =>
+            It.Is<IStorageUploadService.Request>(args =>
                 args.Content == "json-content"
-                && args.RunName == runContext.RunName
                 && args.ContainerName == "json-container"
-                && args.Overwrite),
+                && args.Overwrite
+                && !args.UseUtf8Bom),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/src/EPR.Calculator.API.BackgroundService.UnitTests/Features/Calculator/FileExports/CalculatorFileExporterTests.cs
+++ b/src/EPR.Calculator.API.BackgroundService.UnitTests/Features/Calculator/FileExports/CalculatorFileExporterTests.cs
@@ -35,7 +35,7 @@ public class CalculatorFileGeneratorTests : TestsFor<CalculatorFileGenerator>
 
         storageUploadService = fixture.Freeze<Mock<IStorageUploadService>>();
         storageUploadService.Setup(m => m.UploadFileContentAsync(
-                It.Is<(string, string, string, string, bool)>(a => a.Item4 == "results-container"),
+                It.Is<IStorageUploadService.Request>(a => a.ContainerName == "results-container"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("https://results.uri");
 
@@ -51,11 +51,11 @@ public class CalculatorFileGeneratorTests : TestsFor<CalculatorFileGenerator>
 
         // Assert
         storageUploadService.Verify(x => x.UploadFileContentAsync(
-            It.Is<(string FileName, string Content, string RunName, string ContainerName, bool Overwrite)>(args =>
+            It.Is<IStorageUploadService.Request>(args =>
                 args.Content == "results-content"
-                && args.RunName == runContext.RunName
                 && args.ContainerName == "results-container"
-                && !args.Overwrite),
+                && !args.Overwrite
+                && args.UseUtf8Bom),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/src/EPR.Calculator.API.BackgroundService.UnitTests/Services/BlobStorageUploadServiceTests.cs
+++ b/src/EPR.Calculator.API.BackgroundService.UnitTests/Services/BlobStorageUploadServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Azure;
+﻿using System.Text;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using EPR.Calculator.API.BackgroundService.Services;
@@ -38,24 +39,22 @@ public class BlobStorageServiceTests
     public async Task UploadResultFileContentAsync_ReturnsTrue_WhenUploadSucceeds()
     {
         // Arrange
-        var fileName = "test.txt";
-        var content = "test content";
-        var runName = "test";
-        var containerName = fixture.Create<string>();
+        var request = new IStorageUploadService.Request
+        {
+            FileName = "test.txt",
+            Content = "test content",
+            ContainerName = fixture.Create<string>(),
+        };
+
         var expectedUri = new Uri("https://example.com/test.txt");
 
-        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<BinaryData>(), true, default))
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<Response<BlobContentInfo>>().Object);
         mockBlobClient.Setup(x => x.Uri)
             .Returns(expectedUri);
 
         // Act
-        var result = await sut.UploadFileContentAsync(
-            (FileName: fileName,
-                Content: content,
-                RunName: runName,
-                ContainerName: containerName,
-                Overwrite: true), CancellationToken.None);
+        var result = await sut.UploadFileContentAsync(request, CancellationToken.None);
 
         // Assert
         Assert.AreEqual(result, expectedUri.ToString());
@@ -65,20 +64,74 @@ public class BlobStorageServiceTests
     public async Task UploadResultFileContentAsync_ShouldReturnFalse_WhenUploadFails()
     {
         // Arrange
-        var fileName = "test.txt";
-        var content = "test content";
-        var runName = "test";
-        var containerName = fixture.Create<string>();
+        var request = new IStorageUploadService.Request
+        {
+            FileName = "test.txt",
+            Content = "test content",
+            ContainerName = fixture.Create<string>(),
+        };
 
         mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new TestException());
 
         // Act & Assert
         await Should.ThrowAsync<TestException>(async () => await sut.UploadFileContentAsync(
-            (FileName: fileName,
-                Content: content,
-                RunName: runName,
-                ContainerName: containerName,
-                Overwrite: true), CancellationToken.None));
+            request, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task UploadFileContentAsync_WritesUtf8Bom_WhenUseUtf8BomIsTrue()
+    {
+        // Arrange
+        var request = new IStorageUploadService.Request
+        {
+            FileName = "test.txt",
+            Content = "test content",
+            ContainerName = fixture.Create<string>(),
+            UseUtf8Bom = true
+        };
+
+        BinaryData? uploadedContent = null;
+
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<BinaryData, bool, CancellationToken>((data, _, _) => uploadedContent = data)
+            .ReturnsAsync(new Mock<Response<BlobContentInfo>>().Object);
+        mockBlobClient.Setup(x => x.Uri)
+            .Returns(new Uri("https://example.com/test.csv"));
+
+        // Act
+        await sut.UploadFileContentAsync(request, CancellationToken.None);
+
+        // Assert
+        var bytes = uploadedContent!.ToArray();
+        bytes.Take(3).ShouldBe(new byte[] { 0xEF, 0xBB, 0xBF });
+        bytes.Skip(3).ShouldBe(Encoding.UTF8.GetBytes("test content"));
+    }
+
+    [TestMethod]
+    public async Task UploadFileContentAsync_DoesNotWriteUtf8Bom_WhenUseUtf8BomIsFalse()
+    {
+        // Arrange
+        var request = new IStorageUploadService.Request
+        {
+            FileName = "test.txt",
+            Content = "test content",
+            ContainerName = fixture.Create<string>(),
+            UseUtf8Bom = false
+        };
+        BinaryData? uploadedContent = null;
+
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<BinaryData>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<BinaryData, bool, CancellationToken>((data, _, _) => uploadedContent = data)
+            .ReturnsAsync(new Mock<Response<BlobContentInfo>>().Object);
+        mockBlobClient.Setup(x => x.Uri)
+            .Returns(new Uri("https://example.com/test.json"));
+
+        // Act
+        await sut.UploadFileContentAsync(request, CancellationToken.None);
+
+        // Assert
+        var bytes = uploadedContent!.ToArray();
+        bytes.ShouldBe(Encoding.UTF8.GetBytes("test content"));
     }
 }

--- a/src/EPR.Calculator.API.BackgroundService/Features/BillingRuns/Outputs/BillingFileGenerator.cs
+++ b/src/EPR.Calculator.API.BackgroundService/Features/BillingRuns/Outputs/BillingFileGenerator.cs
@@ -48,12 +48,15 @@ public class BillingFileGenerator(
         var csvFilename = new CalcResultsAndBillingFileName(runContext.RunId, runContext.RunName, runContext.ProcessingStartedAt.UtcDateTime, true);
         var csvContent = await exporter.Export(runContext, calcResults);
 
-        var csvBlobUri = await storageUploadService.UploadFileContentAsync((
-            FileName: csvFilename,
-            Content: csvContent,
-            runContext.RunName,
-            ContainerName: blobStorageUploadOptions.Value.BillingFileCsvContainer,
-            Overwrite: true), ct);
+        var request = new IStorageUploadService.Request
+        {
+            FileName = csvFilename,
+            Content = csvContent,
+            ContainerName = blobStorageUploadOptions.Value.BillingFileCsvContainer,
+            Overwrite = true
+        };
+
+        var csvBlobUri = await storageUploadService.UploadFileContentAsync(request, ct);
 
         return new CalculatorRunCsvFileMetadata
         {
@@ -72,12 +75,16 @@ public class BillingFileGenerator(
         var jsonFilename = new CalcResultsAndBillingFileName(runContext.RunId);
         var jsonContent = await jsonWriter.WriteToString(runContext, calcResults);
 
-        await storageUploadService.UploadFileContentAsync((
-            FileName: jsonFilename,
-            Content: jsonContent,
-            runContext.RunName,
-            ContainerName: blobStorageUploadOptions.Value.BillingFileJsonContainer,
-            Overwrite: true), ct);
+        var request = new IStorageUploadService.Request
+        {
+            FileName = jsonFilename,
+            Content = jsonContent,
+            ContainerName = blobStorageUploadOptions.Value.BillingFileJsonContainer,
+            Overwrite = true,
+            UseUtf8Bom = false
+        };
+
+        await storageUploadService.UploadFileContentAsync(request, ct);
 
         return new CalculatorRunBillingFileMetadata
         {

--- a/src/EPR.Calculator.API.BackgroundService/Features/CalculatorRuns/Outputs/CalculatorFileGenerator.cs
+++ b/src/EPR.Calculator.API.BackgroundService/Features/CalculatorRuns/Outputs/CalculatorFileGenerator.cs
@@ -36,19 +36,21 @@ public class CalculatorFileGenerator(
 
     public async Task<CalculatorRunCsvFileMetadata> HandleCsvFile(CalculatorRunContext runContext, CalcResult calcResult, CancellationToken cancellationToken)
     {
-        var content = await csvWriter.Export(runContext, calcResult);
+        var csvContent = await csvWriter.Export(runContext, calcResult);
 
         var csvFilename = new CalcResultsAndBillingFileName(
             calcResult.CalcResultDetail.RunId,
             calcResult.CalcResultDetail.RunName,
             calcResult.CalcResultDetail.RunDate);
 
-        var csvBlobUri = await storageUploadService.UploadFileContentAsync(
-            (FileName: csvFilename,
-                Content: content,
-                runContext.RunName,
-                ContainerName: blobStorageUploadOptions.Value.ResultFileCsvContainer,
-                Overwrite: false), cancellationToken);
+        var request = new IStorageUploadService.Request
+        {
+            FileName = csvFilename,
+            Content = csvContent,
+            ContainerName = blobStorageUploadOptions.Value.ResultFileCsvContainer
+        };
+
+        var csvBlobUri = await storageUploadService.UploadFileContentAsync(request, cancellationToken);
 
         return new CalculatorRunCsvFileMetadata
         {

--- a/src/EPR.Calculator.API.BackgroundService/Services/BlobStorageUploadService.cs
+++ b/src/EPR.Calculator.API.BackgroundService/Services/BlobStorageUploadService.cs
@@ -1,11 +1,21 @@
-﻿using Azure.Storage.Blobs;
+﻿using System.Text;
+using Azure.Storage.Blobs;
 using EPR.Calculator.API.BackgroundService.Logging;
 
 namespace EPR.Calculator.API.BackgroundService.Services;
 
 public interface IStorageUploadService
 {
-    Task<string> UploadFileContentAsync((string FileName, string Content, string RunName, string ContainerName, bool Overwrite) args, CancellationToken cancellationToken);
+    Task<string> UploadFileContentAsync(Request request, CancellationToken cancellationToken);
+
+    public record Request
+    {
+        public required string FileName { get; init; }
+        public required string Content { get; init; }
+        public required string ContainerName { get; init; }
+        public bool Overwrite { get; init; }
+        public bool UseUtf8Bom { get; init; } = true;
+    }
 }
 
 /// <summary>
@@ -18,16 +28,34 @@ public class BlobStorageUploadService(
 {
     /// <inheritdoc />
     public Task<string> UploadFileContentAsync(
-        (string FileName, string Content, string RunName, string ContainerName, bool Overwrite) args, CancellationToken cancellationToken) =>
+        IStorageUploadService.Request request, CancellationToken cancellationToken) =>
         logger.LogDuration(async () =>
         {
-            var blobContainerClient = blobService.GetBlobContainerClient(args.ContainerName);
+            var blobContainerClient = blobService.GetBlobContainerClient(request.ContainerName);
             await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
-            var blobClient = blobContainerClient.GetBlobClient(args.FileName);
-            var binaryData = BinaryData.FromString(args.Content);
-            await blobClient.UploadAsync(binaryData, args.Overwrite, cancellationToken);
+            var blobClient = blobContainerClient.GetBlobClient(request.FileName);
+            var binaryData = new BinaryData(GetContentBytes(request.Content, request.UseUtf8Bom));
+            await blobClient.UploadAsync(binaryData, request.Overwrite, cancellationToken);
 
             return blobClient.Uri.ToString();
         });
+
+    /// <summary>
+    ///     Encodes <paramref name="content"/> as UTF-8, optionally prefixed with a byte order mark (BOM)
+    ///     so that tools such as Excel correctly detect the encoding when opening the file (e.g. CSVs).
+    /// </summary>
+    private static byte[] GetContentBytes(string content, bool useUtf8Bom)
+    {
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+
+        if (!useUtf8Bom)
+            return contentBytes;
+
+        var bom = Encoding.UTF8.GetPreamble();
+        var bytesWithBom = new byte[bom.Length + contentBytes.Length];
+        Buffer.BlockCopy(bom, 0, bytesWithBom, 0, bom.Length);
+        Buffer.BlockCopy(contentBytes, 0, bytesWithBom, bom.Length, contentBytes.Length);
+        return bytesWithBom;
+    }
 }

--- a/src/EPR.Calculator.API.IntegrationTests/FakeBlobStorageUploadService.cs
+++ b/src/EPR.Calculator.API.IntegrationTests/FakeBlobStorageUploadService.cs
@@ -7,10 +7,10 @@ public class FakeBlobStorageUploadService : IStorageUploadService
     private readonly Dictionary<string, string> store = new();
 
     public Task<string> UploadFileContentAsync(
-        (string FileName, string Content, string RunName, string ContainerName, bool Overwrite) args, CancellationToken cancellationToken = default)
+        IStorageUploadService.Request request, CancellationToken cancellationToken = default)
     {
-        store[args.FileName] = args.Content;
-        return Task.FromResult(args.FileName);
+        store[request.FileName] = request.Content;
+        return Task.FromResult(request.FileName);
     }
 
     public string Get(string fileName)

--- a/src/EPR.Calculator.API.UnitTests/Services/BlobStorageServiceTests.cs
+++ b/src/EPR.Calculator.API.UnitTests/Services/BlobStorageServiceTests.cs
@@ -16,7 +16,6 @@ public class BlobStorageServiceTests
     private const string BillingJsonContainerName = "billing-json";
     private const string FssContainerName = "fss";
     private const string TestFilename = "test-file.csv";
-    private static readonly UnicodeEncoding Utf16 = new(bigEndian: false, byteOrderMark: true);
     private Mock<BlobContainerClient> billingCsvContainer = null!;
     private Mock<BlobContainerClient> billingJsonContainer = null!;
 
@@ -56,90 +55,11 @@ public class BlobStorageServiceTests
         service = new BlobStorageService(blobServiceClient.Object, options, logger.Object);
     }
 
-    // ── Re-encoding behaviour (via OpenResultCsvStream) ─────────────────────
-
-    [TestMethod]
-    public async Task OpenResultCsvStream_ReturnsUtf16WithBom_WhenBlobIsUtf8()
-    {
-        // Arrange
-        const string content = "hello, world";
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, Encoding.UTF8.GetBytes(content));
-
-        // Act
-        var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
-
-        // Assert
-        result.ShouldNotBeNull();
-        AssertIsUtf16WithBom(await ReadBytesAsync(result), content);
-    }
-
-    [TestMethod]
-    public async Task OpenResultCsvStream_ReturnsUtf16WithBom_WhenBlobIsUtf8WithBom()
-    {
-        // Arrange
-        const string content = "test content with UTF-8 BOM";
-        var utf8Bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
-        var bytes = utf8Bom.GetPreamble().Concat(utf8Bom.GetBytes(content)).ToArray();
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, bytes);
-
-        // Act
-        var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
-
-        // Assert
-        result.ShouldNotBeNull();
-        AssertIsUtf16WithBom(await ReadBytesAsync(result), content);
-    }
-
-    [TestMethod]
-    public async Task OpenResultCsvStream_IsIdempotent_WhenBlobIsAlreadyUtf16()
-    {
-        // Arrange
-        const string content = "already UTF-16";
-        var bytes = Utf16.GetPreamble().Concat(Utf16.GetBytes(content)).ToArray();
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, bytes);
-
-        // Act
-        var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
-
-        // Assert
-        result.ShouldNotBeNull();
-        AssertIsUtf16WithBom(await ReadBytesAsync(result), content);
-    }
-
-    [TestMethod]
-    public async Task OpenResultCsvStream_ReturnsUtf16WithBom_WhenBlobIsEmpty()
-    {
-        // Arrange
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, []);
-
-        // Act
-        var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
-
-        // Assert
-        result.ShouldNotBeNull();
-        AssertIsUtf16WithBom(await ReadBytesAsync(result), string.Empty);
-    }
-
-    [TestMethod]
-    public async Task OpenResultCsvStream_PreservesMultibyteUnicodeCharacters()
-    {
-        // Arrange
-        const string content = "H\u00e9llo W\u00f6rld \U0001f30d";
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, Encoding.UTF8.GetBytes(content));
-
-        // Act
-        var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
-
-        // Assert
-        result.ShouldNotBeNull();
-        AssertIsUtf16WithBom(await ReadBytesAsync(result), content);
-    }
-
     [TestMethod]
     public async Task OpenResultCsvStream_ReturnsStreamPositionedAtStart()
     {
         // Arrange
-        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, Encoding.UTF8.GetBytes("position check"));
+        SetupBlobClientWithBytes(resultCsvContainer, TestFilename, "position check"u8.ToArray());
 
         // Act
         var result = await service.OpenResultCsvStream(TestFilename, CancellationToken.None);
@@ -372,28 +292,11 @@ public class BlobStorageServiceTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
 
-    private static async Task<byte[]> ReadBytesAsync(Stream stream)
-    {
-        using var ms = new MemoryStream();
-        await stream.CopyToAsync(ms);
-        return ms.ToArray();
-    }
-
     private static async Task<string> ReadContentAsync(Stream stream)
     {
         // detectEncodingFromByteOrderMarks reads the UTF-16 LE BOM written by ReEncodeAsUtf16Async
         // and decodes the stream correctly, returning the original string content.
         using var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
         return await reader.ReadToEndAsync();
-    }
-
-    private static void AssertIsUtf16WithBom(byte[] bytes, string expectedContent)
-    {
-        var bom = Utf16.GetPreamble();
-        bytes.Length.ShouldBeGreaterThanOrEqualTo(bom.Length);
-        bytes[..bom.Length].ShouldBe(bom, "Expected UTF-16 LE byte-order mark");
-
-        var decoded = Utf16.GetString(bytes, bom.Length, bytes.Length - bom.Length);
-        decoded.ShouldBe(expectedContent);
     }
 }

--- a/src/EPR.Calculator.API/Services/BlobStorageService.cs
+++ b/src/EPR.Calculator.API/Services/BlobStorageService.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Azure;
 using Azure.Storage.Blobs;
 using EPR.Calculator.API.Options;
@@ -49,31 +48,12 @@ public class BlobStorageService : IBlobStorageService
 
         try
         {
-            var blobStream = await blob.OpenReadAsync(cancellationToken: cancellationToken);
-
-            // Preserves existing behaviour - not entirely sure why this is necessary.
-            // Files are currently written/stored as UTF-8.
-            // If UTF-16 is important, files should be written as such to begin with.
-            // This method would then just return blobStream rather than having to re-encode.
-            return await ReEncodeAsUtf16Async(blobStream, cancellationToken);
+            return await blob.OpenReadAsync(cancellationToken: cancellationToken);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
             return null;
         }
-    }
-
-    private static async Task<MemoryStream> ReEncodeAsUtf16Async(Stream source, CancellationToken cancellationToken)
-    {
-        using var reader = new StreamReader(source, detectEncodingFromByteOrderMarks: true);
-        var content = await reader.ReadToEndAsync(cancellationToken);
-
-        var memoryStream = new MemoryStream();
-        await using var writer = new StreamWriter(memoryStream, new UnicodeEncoding(bigEndian: false, byteOrderMark: true), leaveOpen: true);
-        await writer.WriteAsync(content.AsMemory(), cancellationToken);
-        await writer.FlushAsync(cancellationToken);
-        memoryStream.Position = 0;
-        return memoryStream;
     }
 
     private async Task<bool> MoveBlob(BlobContainerClient source, BlobContainerClient destination, string blobName, CancellationToken cancellationToken)


### PR DESCRIPTION
Eliminates unnecessary re-encoding logic when retrieving CSV files from blob storage. Previously, the service forced a conversion from the stored format (typically UTF-8) to UTF-16 with a Byte Order Mark (BOM). 

By returning the raw blob stream directly:
- Performance is improved by avoiding full-stream buffering and string conversion in memory
- The service remains agnostic of the underlying file encoding
- Code complexity is reduced by removing redundant helper methods and associated unit tests

Relates to ECV-686